### PR TITLE
Fixes getUserFollows and getUserFollower

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -226,7 +226,7 @@ class Instagram
      */
     public function getUserFollows($id = 'self', $limit = 0)
     {
-        $this->getFollows();
+        $this->getFollows($id, $limit);
     }
 
     /**
@@ -234,9 +234,12 @@ class Instagram
      *
      * @return mixed
      */
-    public function getFollows()
+    public function getFollows($id, $limit)
     {
-        return $this->_makeCall('users/self/follows');
+        if ($limit > 0) {
+            $params['count'] = $limit;
+        }
+        return $this->_makeCall('users/' . $id . '/follows', $params);
     }
 
     /**
@@ -250,7 +253,7 @@ class Instagram
      */
     public function getUserFollower($id = 'self', $limit = 0)
     {
-        $this->getFollower();
+        return $this->getFollower($id, $limit);
     }
 
     /**
@@ -258,9 +261,12 @@ class Instagram
      *
      * @return mixed
      */
-    public function getFollower()
+    public function getFollower($id, $limit)
     {
-        return $this->_makeCall('users/self/followed-by');
+        if ($limit > 0) {
+            $params['count'] = $limit;
+        }
+        return $this->_makeCall('users/' . $id . '/followed-by', $params);
     }
 
     /**

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -226,7 +226,7 @@ class Instagram
      */
     public function getUserFollows($id = 'self', $limit = 0)
     {
-        $this->getFollows($id, $limit);
+        return $this->getFollows($id, $limit);
     }
 
     /**

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -234,11 +234,14 @@ class Instagram
      *
      * @return mixed
      */
-    public function getFollows($id, $limit)
+    public function getFollows($id = 'self', $limit = 0)
     {
+        $params = array();
+
         if ($limit > 0) {
             $params['count'] = $limit;
         }
+
         return $this->_makeCall('users/' . $id . '/follows', $params);
     }
 
@@ -261,11 +264,14 @@ class Instagram
      *
      * @return mixed
      */
-    public function getFollower($id, $limit)
+    public function getFollower($id = 'self', $limit = 0)
     {
+        $params = array();
+
         if ($limit > 0) {
             $params['count'] = $limit;
         }
+
         return $this->_makeCall('users/' . $id . '/followed-by', $params);
     }
 


### PR DESCRIPTION
Readme states that `getUserFollows()` and `getUserFollower()` accepts an `$id` and `$limit`, however these were never used.  Also, nothing was ever returned.
